### PR TITLE
Unit should turn to cell before moving

### DIFF
--- a/src/main/java/com/fundynamic/d2tm/game/behaviors/Updateable.java
+++ b/src/main/java/com/fundynamic/d2tm/game/behaviors/Updateable.java
@@ -3,5 +3,10 @@ package com.fundynamic.d2tm.game.behaviors;
 
 public interface Updateable {
 
+    /**
+     * Update internal state, with given float value of passed time in seconds. With high FPS, the deltaInSeconds
+     * is very low. Ie, 2 FPS means deltaInSeconds of 0.5
+     * @param deltaInSeconds
+     */
     void update(float deltaInSeconds);
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/EntitiesData.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/EntitiesData.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 public class EntitiesData {
 
     public static final String UNKNOWN = "UNKNOWN";
+
     // units
     public static String TRIKE = "TRIKE";
     public static String QUAD = "QUAD";
@@ -74,9 +75,10 @@ public class EntitiesData {
         }
     }
 
-    public void addUnit(String id, String pathToImage, int widthInPixels, int heightInPixels, int sight, float moveSpeed, int hitPoints, String weaponId, String explosionId) throws SlickException {
+    public void addUnit(String id, String pathToImage, int widthInPixels, int heightInPixels, int sight, float moveSpeed, float turnSpeed, int hitPoints, String weaponId, String explosionId) throws SlickException {
         EntityData entity = createEntity(id, pathToImage, widthInPixels, heightInPixels, EntityType.UNIT, sight, moveSpeed, hitPoints);
 
+        entity.turnSpeed = turnSpeed;
         if (!idProvided(weaponId)) {
             if (!tryGetEntityData(EntityType.PROJECTILE, weaponId)) {
                 throw new IllegalArgumentException("unit " + id + " [weapon] refers to non-existing [WEAPONS/" + weaponId + "]");

--- a/src/main/java/com/fundynamic/d2tm/game/entities/EntitiesDataReader.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/EntitiesDataReader.java
@@ -10,6 +10,9 @@ import java.io.InputStream;
 
 import static com.fundynamic.d2tm.game.entities.EntitiesData.UNKNOWN;
 
+/**
+ * Reads the 'rules.ini' file and extracts an EntitiesData data structure.
+ */
 public class EntitiesDataReader {
 
     public EntitiesData fromRulesIni() {
@@ -76,6 +79,7 @@ public class EntitiesDataReader {
                     struct.get("height", Integer.class, 1),
                     struct.get("sight", Integer.class, 1),
                     struct.get("movespeed", Float.class, 0f),
+                    struct.get("turnspeed", Float.class, 0f),
                     struct.get("hitpoints", Integer.class, 0),
                     struct.get("weapon", String.class, UNKNOWN),
                     struct.get("explosion", String.class));

--- a/src/main/java/com/fundynamic/d2tm/game/entities/EntityData.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/EntityData.java
@@ -16,7 +16,9 @@ public class EntityData {
 
     public int sight;
 
-    public float moveSpeed;
+    public float moveSpeed; // the speed a unit moves: value is pixels in seconds.
+    public float turnSpeed; // the speed a unit turns: value is facing angles in seconds. < 1 means
+
     public int hitPoints;
 
     private int facings;
@@ -107,5 +109,24 @@ public class EntityData {
 
     public static String constructKey(EntityType entityType, String id) {
         return entityType.toString() + "-" + id;
+    }
+
+    /**
+     * This takes time into account as well. This makes the distance of moveSpeed equivalent to 1 second.
+     *
+     * @param deltaInSeconds
+     * @return
+     */
+    public float getRelativeMoveSpeed(float deltaInSeconds) {
+        return moveSpeed * deltaInSeconds;
+    }
+
+    /**
+     * See @link getRelativeMoveSpeed
+     * @param deltaInSeconds
+     * @return
+     */
+    public float getRelativeTurnSpeed(float deltaInSeconds) {
+        return turnSpeed * deltaInSeconds;
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/EntityRepository.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/EntityRepository.java
@@ -107,40 +107,37 @@ public class EntityRepository {
         System.out.println("Placing " + entityData + " on map at " + absoluteMapCoordinates + " for " + player);
         Entity createdEntity;
         Image originalImage = entityData.image;
-        Image recoloredImage = originalImage;
-        SpriteSheet spriteSheet;
 
-        switch (entityData.type) {
-            case STRUCTURE:
-                recoloredImage = recolorer.recolorToFactionColor(originalImage, player.getFactionColor());
-                createdEntity = new Structure(absoluteMapCoordinates, recoloredImage, player, entityData, this);
-                addEntityToList(map.placeStructure((Structure) createdEntity));
-                break;
-            case UNIT:
-                recoloredImage = recolorer.recolorToFactionColor(originalImage, player.getFactionColor());
-                spriteSheet = new SpriteSheet(recoloredImage, entityData.width, entityData.height);
-                createdEntity = new Unit(map, absoluteMapCoordinates, spriteSheet, player, entityData, this);
-                addEntityToList(map.placeUnit((Unit) createdEntity));
-                break;
-            case PROJECTILE:
-                spriteSheet = new SpriteSheet(recoloredImage, entityData.width, entityData.height);
-                createdEntity = new Projectile(absoluteMapCoordinates, spriteSheet, player, entityData, this);
-                addEntityToList(map.placeProjectile((Projectile) createdEntity));
-                break;
-            case PARTICLE:
-                spriteSheet = new SpriteSheet(recoloredImage, entityData.width, entityData.height);
-                createdEntity = new Particle(absoluteMapCoordinates, spriteSheet, entityData, this);
-                addEntityToList(createdEntity);
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown type " + entityData.type);
+        if (EntityType.STRUCTURE.equals(entityData.type)) {
+            Image recoloredImage = recolorer.recolorToFactionColor(originalImage, player.getFactionColor());
+            createdEntity = new Structure(absoluteMapCoordinates, recoloredImage, player, entityData, this);
+            return addEntityToList(map.placeStructure((Structure) createdEntity));
+        } else if (EntityType.UNIT.equals(entityData.type)) {
+            Image recoloredImage = recolorer.recolorToFactionColor(originalImage, player.getFactionColor());
+            SpriteSheet spriteSheet = makeSpriteSheet(entityData, recoloredImage);
+            createdEntity = new Unit(map, absoluteMapCoordinates, spriteSheet, player, entityData, this);
+            return addEntityToList(map.placeUnit((Unit) createdEntity));
+        } else if (EntityType.PROJECTILE.equals(entityData.type)) {
+            SpriteSheet spriteSheet = makeSpriteSheet(entityData, originalImage);
+            createdEntity = new Projectile(absoluteMapCoordinates, spriteSheet, player, entityData, this);
+            return addEntityToList(map.placeProjectile((Projectile) createdEntity));
+        }  else if (EntityType.PARTICLE.equals(entityData.type)) {
+            SpriteSheet spriteSheet = makeSpriteSheet(entityData, originalImage);
+            createdEntity = new Particle(absoluteMapCoordinates, spriteSheet, entityData, this);
+            return addEntityToList(createdEntity);
+        } else {
+            throw new IllegalArgumentException("Unknown type " + entityData.type);
         }
-        return createdEntity;
     }
 
-    public void addEntityToList(Entity entity) {
+    public SpriteSheet makeSpriteSheet(EntityData entityData, Image recoloredImage) {
+        return new SpriteSheet(recoloredImage, entityData.width, entityData.height);
+    }
+
+    public Entity addEntityToList(Entity entity) {
         lastCreatedEntity = entity;
         entitiesSet.add(entity);
+        return entity;
     }
 
     public void removeEntities(Predicate predicate) {

--- a/src/main/java/com/fundynamic/d2tm/game/entities/EntityRepository.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/EntityRepository.java
@@ -244,4 +244,8 @@ public class EntityRepository {
     public Entity getLastCreatedEntity() {
         return lastCreatedEntity;
     }
+
+    public Entity placeProjectile(Vector2D absoluteCoordinates, String id, Player player) {
+        return placeOnMap(absoluteCoordinates, EntityType.PROJECTILE, id, player);
+    }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/projectiles/Projectile.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/projectiles/Projectile.java
@@ -50,7 +50,7 @@ public class Projectile extends Entity implements Moveable, Destructible {
     @Override
     public void update(float deltaInSeconds) {
         if (target != absoluteCoordinates) {
-            float timeCorrectedSpeed = entityData.moveSpeed * deltaInSeconds;
+            float timeCorrectedSpeed = entityData.getRelativeMoveSpeed(deltaInSeconds);
             Vector2D direction = target.min(absoluteCoordinates);
             Vector2D normalised = direction.normalise();
 

--- a/src/main/java/com/fundynamic/d2tm/game/entities/projectiles/Projectile.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/projectiles/Projectile.java
@@ -4,6 +4,7 @@ package com.fundynamic.d2tm.game.entities.projectiles;
 import com.fundynamic.d2tm.game.behaviors.Destructible;
 import com.fundynamic.d2tm.game.behaviors.Moveable;
 import com.fundynamic.d2tm.game.entities.*;
+import com.fundynamic.d2tm.game.entities.units.UnitFacings;
 import com.fundynamic.d2tm.math.Vector2D;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
@@ -38,18 +39,10 @@ public class Projectile extends Entity implements Moveable, Destructible {
         return spriteSheet.getSprite(getFacing(absoluteCoordinates, target), 0);
     }
 
-    /**
-     * Calculates facing index.
-     *
-     * @return
-     */
     public int getFacing(Vector2D from, Vector2D to) {
         int facing = 0;
         if (entityData.hasFacings() && !from.equals(to)) {
-            double angle = from.angleTo(to);
-            float chop = entityData.getChop();
-            angle += (chop / 2);
-            facing = (int) (angle / chop) % entityData.getFacings();
+            facing = UnitFacings.calculateFacingSpriteIndex(from, to, entityData.getFacings(), entityData.getChop());
         }
         return facing;
     }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
@@ -212,21 +212,7 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
     }
 
     public UnitFacings determineFacingFor(Vector2D coordinatesToFaceTo) {
-        boolean left = coordinatesToFaceTo.getXAsInt() < absoluteCoordinates.getXAsInt();
-        boolean right = coordinatesToFaceTo.getXAsInt() > absoluteCoordinates.getXAsInt();
-        boolean up = coordinatesToFaceTo.getYAsInt() < absoluteCoordinates.getYAsInt();
-        boolean down = coordinatesToFaceTo.getYAsInt() > absoluteCoordinates.getYAsInt();
-
-        if (up && left) return UnitFacings.LEFT_UP;
-        if (up && right) return UnitFacings.RIGHT_UP;
-        if (down && left) return UnitFacings.LEFT_DOWN;
-        if (down && right) return UnitFacings.RIGHT_DOWN;
-        if (up) return UnitFacings.UP;
-        if (down) return UnitFacings.DOWN;
-        if (left) return UnitFacings.LEFT;
-        if (right) return UnitFacings.RIGHT;
-
-        return UnitFacings.byId(facing);
+       return UnitFacings.determine(absoluteCoordinates, coordinatesToFaceTo);
     }
 
     @Override

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
@@ -106,7 +106,6 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
         float offsetX = offset.getX();
         float offsetY = offset.getY();
 
-        // TODO: moveSpeed has no relation with time!? - need to fix that
         if (nextTargetToMoveTo.getXAsInt() < absoluteCoordinates.getXAsInt()) offsetX -= entityData.getRelativeMoveSpeed(deltaInSeconds);
         if (nextTargetToMoveTo.getXAsInt() > absoluteCoordinates.getXAsInt()) offsetX += entityData.getRelativeMoveSpeed(deltaInSeconds);
         if (nextTargetToMoveTo.getYAsInt() < absoluteCoordinates.getYAsInt()) offsetY -= entityData.getRelativeMoveSpeed(deltaInSeconds);

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/Unit.java
@@ -31,7 +31,9 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
 
     // Drawing 'movement' from cell to cell
     private Vector2D offset;
-    private int facing;
+    private float facing;
+    private int desiredFacing;
+
     private float moveSpeed;
 
     private boolean hasSpawnedExplosions;
@@ -56,6 +58,7 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
 
         int possibleFacings = spriteSheet.getHorizontalCount();
         this.facing = Random.getRandomBetween(0, possibleFacings);
+        this.desiredFacing = (int) facing;
         this.fadingSelection = fadingSelection;
         this.hitPointBasedDestructibility = hitPointBasedDestructibility;
         this.target = absoluteMapCoordinates;
@@ -89,9 +92,12 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
             if (hasNoNextCellToMoveTo()) {
                 decideWhatCellToMoveToNextOrStopMovingWhenNotPossible();
             } else {
-                // TODO: "make it turn to facing"
-                facing = determineFacingFor(nextTargetToMoveTo).getValue();
-                moveToNextCellPixelByPixel();
+                if (desiredFacing == (int) facing) {
+                    moveToNextCellPixelByPixel();
+                } else {
+                    float turnSpeed = 0.1f;
+                    facing = UnitFacings.turnTo(facing, desiredFacing, turnSpeed);
+                }
             }
         }
 
@@ -149,6 +155,7 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
 
         if (entities.isEmpty() && !UnitMoveIntents.hasIntentFor(intendedMapCoordinatesToMoveTo)) {
             this.nextTargetToMoveTo = intendedMapCoordinatesToMoveTo;
+            this.desiredFacing = determineFacingFor(nextTargetToMoveTo).getValue();
             UnitMoveIntents.addIntent(nextTargetToMoveTo);
         }
     }
@@ -173,7 +180,7 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
     }
 
     public Image getSprite() {
-        return spriteSheet.getSprite(facing, 0);
+        return spriteSheet.getSprite((int) facing, 0);
     }
 
     @Override
@@ -212,7 +219,7 @@ public class Unit extends Entity implements Selectable, Moveable, Destructible, 
     }
 
     public UnitFacings determineFacingFor(Vector2D coordinatesToFaceTo) {
-       return UnitFacings.determine(absoluteCoordinates, coordinatesToFaceTo);
+       return UnitFacings.getFacing(absoluteCoordinates, coordinatesToFaceTo);
     }
 
     @Override

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
@@ -96,4 +96,13 @@ public enum UnitFacings {
         return counterClockwise;
     }
 
+    // TODO: this looks very similar to the Projectile determine facing logic, move to somewhere else!?
+    public static UnitFacings getFacing(Vector2D from, Vector2D to) {
+        double angle = from.angleTo(to);
+        int facings = 8; // 8 facings in total for a unit
+        float chop = 360F / facings;
+        angle += (chop / 2);
+        int facing = (int) (angle / chop) % facings;
+        return byId(facing);
+    }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
@@ -6,6 +6,8 @@ import com.fundynamic.d2tm.math.Vector2D;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.lang.Math.abs;
+
 public enum UnitFacings {
     RIGHT(0),
     RIGHT_UP(1),
@@ -54,6 +56,44 @@ public enum UnitFacings {
         if (right) return UnitFacings.RIGHT;
 
         return UnitFacings.RIGHT;
+    }
+
+    public static UnitFacings nextFacing(UnitFacings current, UnitFacings desired) {
+        int currentId = current.getValue();
+        int desiredId = desired.getValue();
+
+        int counterClockwise = getCounterClockwiseSteps(currentId, desiredId);
+        int clockwise = getClockwiseSteps(currentId, desiredId);
+
+        // Decide what the nextId (facing) should be
+        int newId = currentId;
+        if (counterClockwise < clockwise) {
+            newId++; // go counter-clockwise, which means go 'right' on the sprite
+        } else {
+            newId--; // go clock-wise which means go 'left' on the sprite
+        }
+
+        // make sure we stay within range
+        if (newId < 0) newId = 7;
+        if (newId > 7) newId = 0;
+
+        return byId(newId);
+    }
+
+    public static int getClockwiseSteps(int currentId, int desiredId) {
+        int clockwise = abs(currentId - (desiredId - 7));
+        if (clockwise > 7) clockwise -= 8;
+        return clockwise;
+    }
+
+    public static int getCounterClockwiseSteps(int currentId, int desiredId) {
+        int counterClockwise;
+        if (desiredId < currentId) {
+            counterClockwise = abs((currentId + desiredId) - 8);
+        } else {
+            counterClockwise = abs(desiredId - currentId);
+        }
+        return counterClockwise;
     }
 
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
@@ -58,26 +58,26 @@ public enum UnitFacings {
         return UnitFacings.RIGHT;
     }
 
-    public static UnitFacings nextFacing(UnitFacings current, UnitFacings desired) {
-        int currentId = current.getValue();
-        int desiredId = desired.getValue();
-
-        int counterClockwise = getCounterClockwiseSteps(currentId, desiredId);
-        int clockwise = getClockwiseSteps(currentId, desiredId);
-
+    public static int nextFacing(int current, int desired) {
         // Decide what the nextId (facing) should be
-        int newId = currentId;
-        if (counterClockwise < clockwise) {
-            newId++; // go counter-clockwise, which means go 'right' on the sprite
-        } else {
-            newId--; // go clock-wise which means go 'left' on the sprite
-        }
+        int newId = current + facingDirection(current, desired);
 
         // make sure we stay within range
         if (newId < 0) newId = 7;
         if (newId > 7) newId = 0;
 
-        return byId(newId);
+        return newId;
+    }
+
+    public static int facingDirection(int current, int desired) {
+        int counterClockwise = getCounterClockwiseSteps(current, desired);
+        int clockwise = getClockwiseSteps(current, desired);
+
+        // Decide what the nextId (facing) should be
+        if (counterClockwise < clockwise) {
+            return 1; // go counter-clockwise, which means go 'right' on the sprite
+        }
+        return -1; // go clock-wise which means go 'left' on the sprite
     }
 
     public static int getClockwiseSteps(int currentId, int desiredId) {
@@ -110,5 +110,12 @@ public enum UnitFacings {
         double angle = from.angleTo(to);
         angle += (chop / 2);
         return (int) (angle / chop) % facings;
+    }
+
+    public static float turnTo(float facing, int desiredFacing, float turnSpeed) {
+        float newFacing = facing + (facingDirection((int) facing, desiredFacing) * turnSpeed);
+        if (newFacing < 0) newFacing = 7;
+        if (newFacing > 7) newFacing = 0;
+        return newFacing;
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
@@ -98,11 +98,17 @@ public enum UnitFacings {
 
     // TODO: this looks very similar to the Projectile determine facing logic, move to somewhere else!?
     public static UnitFacings getFacing(Vector2D from, Vector2D to) {
-        double angle = from.angleTo(to);
         int facings = 8; // 8 facings in total for a unit
-        float chop = 360F / facings;
+        return byId(calculateFacingSpriteIndex(from, to, facings));
+    }
+
+    public static int calculateFacingSpriteIndex(Vector2D from, Vector2D to, int facings) {
+        return calculateFacingSpriteIndex(from, to, facings, 360F / facings);
+    }
+
+    public static int calculateFacingSpriteIndex(Vector2D from, Vector2D to, int facings, float chop) {
+        double angle = from.angleTo(to);
         angle += (chop / 2);
-        int facing = (int) (angle / chop) % facings;
-        return byId(facing);
+        return (int) (angle / chop) % facings;
     }
 }

--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/UnitFacings.java
@@ -1,6 +1,8 @@
 package com.fundynamic.d2tm.game.entities.units;
 
 
+import com.fundynamic.d2tm.math.Vector2D;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,4 +37,23 @@ public enum UnitFacings {
     public static UnitFacings byId(int id) {
         return facingsById.get(id);
     }
+
+    public static UnitFacings determine(Vector2D from, Vector2D to) {
+        boolean left = to.getXAsInt() < from.getXAsInt();
+        boolean right = to.getXAsInt() > from.getXAsInt();
+        boolean up = to.getYAsInt() < from.getYAsInt();
+        boolean down = to.getYAsInt() > from.getYAsInt();
+
+        if (up && left) return UnitFacings.LEFT_UP;
+        if (up && right) return UnitFacings.RIGHT_UP;
+        if (down && left) return UnitFacings.LEFT_DOWN;
+        if (down && right) return UnitFacings.RIGHT_DOWN;
+        if (up) return UnitFacings.UP;
+        if (down) return UnitFacings.DOWN;
+        if (left) return UnitFacings.LEFT;
+        if (right) return UnitFacings.RIGHT;
+
+        return UnitFacings.RIGHT;
+    }
+
 }

--- a/src/main/resources/rules.ini
+++ b/src/main/resources/rules.ini
@@ -53,7 +53,9 @@ image=units/quad.png
 width=32
 height=32
 sight=3
-movespeed=1.5
+# moves 2 squares in 1 second
+movespeed=64
+turnspeed=2
 hitpoints=200
 explosion=WHEELED
 weapon=RIFLE
@@ -64,7 +66,9 @@ image=units/trike.png
 width=28
 height=26
 sight=4
-movespeed=2.5
+# moves 2.5 squares in 1 second
+movespeed=80
+turnspeed=2.5
 hitpoints=125
 explosion=WHEELED
 weapon=RIFLE

--- a/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
@@ -159,44 +159,24 @@ public abstract class AbstractD2TMTest {
     // UNIT
     ////////////////////////////////////////////////////////////////////////////////
     public Unit makeUnit(UnitFacings facing, Vector2D unitAbsoluteMapCoordinates) {
-        return makeUnit(facing, unitAbsoluteMapCoordinates, Vector2D.zero(), 100);
+        return makeUnit(facing, unitAbsoluteMapCoordinates, Vector2D.zero());
     }
 
-    public Unit makeUnit(UnitFacings facing, Vector2D unitAbsoluteMapCoordinates, Vector2D offset, int hitPoints) {
-        Unit unit = makeUnit(player, hitPoints, unitAbsoluteMapCoordinates);
+    public Unit makeUnit(UnitFacings facing, Vector2D unitAbsoluteMapCoordinates, Vector2D offset) {
+        Unit unit = makeUnit(player, unitAbsoluteMapCoordinates);
         unit.setFacing(facing.getValue());
         unit.setOffset(offset);
         return unit;
     }
 
-    public Unit makeUnit(Player player, int hitPoints) {
-        return makeUnit(player, hitPoints, Vector2D.zero());
+    public Unit makeUnit(Player player) {
+        return makeUnit(player, Vector2D.zero());
     }
 
-    public Unit makeUnit(Player player, int hitPoints, Vector2D absoluteMapCoordinates) {
+    public Unit makeUnit(Player player, Vector2D absoluteMapCoordinates) {
         if (entityRepository == null) throw new IllegalStateException("You forgot to set up the entityRepository, probably you need to do super.setUp()");
         if (map == null) throw new IllegalStateException("You forgot to set up the map, probably you need to do super.setUp()");
-        EntityData entityData = new EntityData(32, 32, 2);
-        entityData.moveSpeed = 1; // 1 pixel per second
-        entityData.turnSpeed = 1; // 1 facing per second
-        entityData.hitPoints = hitPoints;
-        Unit unit = new Unit(
-                map,
-                absoluteMapCoordinates,
-                mock(SpriteSheet.class),
-                player,
-                entityData,
-                entityRepository) {
-            @Override
-            public boolean isDestroyed() {
-                // we do this so that we do not have to deal with spawning explosions (which is done in the
-                // update method of the 'original' unit.)
-                return super.hitPointBasedDestructibility.hasDied();
-            }
-        };
-        entityRepository.addEntityToList(unit);
-        map.placeUnit(unit);
-        return unit;
+        return (Unit) entityRepository.placeOnMap(absoluteMapCoordinates, EntityType.UNIT, "QUAD", player);
     }
 
     public EntityRepository getTestableEntityRepository() {
@@ -207,7 +187,12 @@ public abstract class AbstractD2TMTest {
         Image image = mock(Image.class);
         Recolorer recolorer = mock(Recolorer.class);
         when(recolorer.recolorToFactionColor(any(Image.class), any(Recolorer.FactionColor.class))).thenReturn(image);
-        return new EntityRepository(map, recolorer, entitiesData);
+        return new EntityRepository(map, recolorer, entitiesData) {
+            @Override
+            public SpriteSheet makeSpriteSheet(EntityData entityData, Image recoloredImage) {
+                return mock(SpriteSheet.class);
+            }
+        };
     }
 
 }

--- a/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
@@ -5,6 +5,7 @@ import com.fundynamic.d2tm.Game;
 import com.fundynamic.d2tm.game.controls.Mouse;
 import com.fundynamic.d2tm.game.controls.TestableMouse;
 import com.fundynamic.d2tm.game.entities.*;
+import com.fundynamic.d2tm.game.entities.projectiles.Projectile;
 import com.fundynamic.d2tm.game.entities.structures.Structure;
 import com.fundynamic.d2tm.game.entities.units.Unit;
 import com.fundynamic.d2tm.game.entities.units.UnitFacings;
@@ -178,6 +179,13 @@ public abstract class AbstractD2TMTest {
         if (map == null) throw new IllegalStateException("You forgot to set up the map, probably you need to do super.setUp()");
         return (Unit) entityRepository.placeOnMap(absoluteMapCoordinates, EntityType.UNIT, "QUAD", player);
     }
+
+    // PROJECTILE
+    ////////////////////////////////////////////////////////////////////////////////
+    public Projectile makeProjectile(Vector2D absoluteCoordinates) {
+        return (Projectile) entityRepository.placeProjectile(absoluteCoordinates, "LARGE_ROCKET", player);
+    }
+
 
     public EntityRepository getTestableEntityRepository() {
         return entityRepository;

--- a/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/AbstractD2TMTest.java
@@ -177,7 +177,8 @@ public abstract class AbstractD2TMTest {
         if (entityRepository == null) throw new IllegalStateException("You forgot to set up the entityRepository, probably you need to do super.setUp()");
         if (map == null) throw new IllegalStateException("You forgot to set up the map, probably you need to do super.setUp()");
         EntityData entityData = new EntityData(32, 32, 2);
-        entityData.moveSpeed = 1.0f; // 1 pixel per frame
+        entityData.moveSpeed = 1; // 1 pixel per second
+        entityData.turnSpeed = 1; // 1 facing per second
         entityData.hitPoints = hitPoints;
         Unit unit = new Unit(
                 map,

--- a/src/test/java/com/fundynamic/d2tm/game/controls/MovableSelectedMouseTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/controls/MovableSelectedMouseTest.java
@@ -25,7 +25,7 @@ public class MovableSelectedMouseTest extends AbstractMouseBehaviorTest {
 
     @Test
     public void leftClickedSelectsUnitOnHoverCell() throws SlickException {
-        Unit unit = makeUnit(player, 100, Vector2D.create(32, 32));
+        Unit unit = makeUnit(player, Vector2D.create(32, 32));
         assertThat(unit.isSelected(), is(false));
 
         mouse.mouseMovedToCell(map.getCell(1, 1)); // equals 32, 32
@@ -37,7 +37,7 @@ public class MovableSelectedMouseTest extends AbstractMouseBehaviorTest {
     @Test
     public void movesSelectedUnitsToCellThatIsNotOccupiedByOtherCell() throws SlickException {
 
-        Unit unit = makeUnit(player, 100, Vector2D.create(32, 32));
+        Unit unit = makeUnit(player, Vector2D.create(32, 32));
         unit.select();
 
         // TODO: This is ugly because absolute coordinates are used here versus map coordinates above in test
@@ -54,11 +54,11 @@ public class MovableSelectedMouseTest extends AbstractMouseBehaviorTest {
     @Test
     public void attacksUnitOfOtherPlayer() {
         // create player for unit and select it
-        Unit unit = makeUnit(player, 100, Vector2D.create(32, 32));
+        Unit unit = makeUnit(player, Vector2D.create(32, 32));
         unit.select();
 
         Player enemy = new Player("Enemy", Recolorer.FactionColor.RED);
-        Unit enemyUnit = makeUnit(enemy, 100, Vector2D.create(64, 64));
+        Unit enemyUnit = makeUnit(enemy, Vector2D.create(64, 64));
         map.placeUnit(enemyUnit);
 
         Cell cell = map.getCellByAbsoluteMapCoordinates(Vector2D.create(64, 64));

--- a/src/test/java/com/fundynamic/d2tm/game/controls/NormalMouseTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/controls/NormalMouseTest.java
@@ -29,7 +29,7 @@ public class NormalMouseTest extends AbstractMouseBehaviorTest {
         mouse.setHoverCell(cell);
 
         Vector2D coordinatesAsAbsoluteVector2D = cell.getCoordinatesAsAbsoluteVector2D();
-        Unit unit = makeUnit(player, 100, coordinatesAsAbsoluteVector2D);
+        Unit unit = makeUnit(player, coordinatesAsAbsoluteVector2D);
         assertThat(unit.isSelected(), is(false));
 
         // ACT: click left

--- a/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesDataReaderTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesDataReaderTest.java
@@ -47,6 +47,7 @@ public class EntitiesDataReaderTest {
         assertThat(quad.image, is(not(nullValue())));
         assertThat(quad.hitPoints, is(434));
         assertThat(quad.moveSpeed, is(1.5F));
+        assertThat(quad.turnSpeed, is(0.75F));
         assertThat(quad.width, is(32));
         assertThat(quad.height, is(32));
         assertThat(quad.sight, is(7));

--- a/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesDataTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesDataTest.java
@@ -6,7 +6,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.newdawn.slick.SlickException;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class EntitiesDataTest extends AbstractD2TMTest {
 
@@ -24,9 +26,10 @@ public class EntitiesDataTest extends AbstractD2TMTest {
         String idOfEntity = "1";
         int sight = 2;
         float moveSpeed = 1.0F;
+        float turnSpeed = 2.0F;
         String weaponId = "UNKNOWN";
         String explosionId = "UNKNOWN";
-        entitiesData.addUnit(idOfEntity, "quad.png", widthInPixels, heightInPixels, sight, moveSpeed, hitPoints, weaponId, explosionId);
+        entitiesData.addUnit(idOfEntity, "quad.png", widthInPixels, heightInPixels, sight, moveSpeed, turnSpeed, hitPoints, weaponId, explosionId);
 
         EntityData data = entitiesData.getEntityData(EntityType.UNIT, idOfEntity);
 
@@ -34,6 +37,8 @@ public class EntitiesDataTest extends AbstractD2TMTest {
         assertEquals(widthInPixels, data.width);
         assertEquals(heightInPixels, data.height);
         assertEquals(sight, data.sight);
+        assertThat(moveSpeed, is(data.moveSpeed));
+        assertThat(turnSpeed, is(data.turnSpeed));
         assertEquals(hitPoints, data.hitPoints);
         assertEquals(explosionId, data.explosionId);
         assertEquals(weaponId, data.weaponId);
@@ -42,8 +47,8 @@ public class EntitiesDataTest extends AbstractD2TMTest {
     @Test (expected = IllegalArgumentException.class)
     public void createUnitWithDuplicateIdThrowsIllegalArgumentException() throws SlickException {
         String idOfEntity = "1";
-        entitiesData.addUnit(idOfEntity, "quad.png", 32, 32, 2, 1.0F, 100, "0", "1"); // success!
-        entitiesData.addUnit(idOfEntity, "this is irrelevant", 32, 32, 3, 1.0F, 100, "0", "1"); // boom!
+        entitiesData.addUnit(idOfEntity, "quad.png", 32, 32, 2, 1.0F, 1.0F, 100, "0", "1"); // success!
+        entitiesData.addUnit(idOfEntity, "this is irrelevant", 32, 32, 3, 1.0F, 1.0F, 100, "0", "1"); // boom!
     }
 
     @Test (expected = EntityNotFoundException.class)

--- a/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesSetTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/EntitiesSetTest.java
@@ -39,10 +39,10 @@ public class EntitiesSetTest extends AbstractD2TMTest {
         Player playerTwo = new Player("Player two", Recolorer.FactionColor.RED);
 
         // player one has 4 units and 2 structures
-        entitiesSet.add(makeUnit(player, 100, Vector2D.create(320, 320)));
-        entitiesSet.add(makeUnit(player, 200, Vector2D.create(384, 320)));
-        entitiesSet.add(makeUnit(player, 300, Vector2D.create(320, 384)));
-        entitiesSet.add(makeUnit(player, 200, Vector2D.create(960, 960)));
+        entitiesSet.add(makeUnit(player, Vector2D.create(320, 320)));
+        entitiesSet.add(makeUnit(player, Vector2D.create(384, 320)));
+        entitiesSet.add(makeUnit(player, Vector2D.create(320, 384)));
+        entitiesSet.add(makeUnit(player, Vector2D.create(960, 960)));
         playerOneUnitCount = 4;
         moveableUnitsOfPlayerOne = 4;
         destroyers = 4;
@@ -52,9 +52,9 @@ public class EntitiesSetTest extends AbstractD2TMTest {
         playerOneStructureCount = 2;
 
         // player two has 3 units and 3 structures
-        entitiesSet.add(makeUnit(playerTwo, 100));
-        entitiesSet.add(makeUnit(playerTwo, 200));
-        entitiesSet.add(makeUnit(playerTwo, 300));
+        entitiesSet.add(makeUnit(playerTwo));
+        entitiesSet.add(makeUnit(playerTwo));
+        entitiesSet.add(makeUnit(playerTwo));
         destroyers += 3;
 
         entitiesSet.add(makeStructure(playerTwo, 200));

--- a/src/test/java/com/fundynamic/d2tm/game/entities/EntityRepositoryTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/EntityRepositoryTest.java
@@ -18,7 +18,7 @@ public class EntityRepositoryTest extends AbstractD2TMTest {
 
     @Test
     public void findsUnitAtVector() throws SlickException {
-        Unit unit = makeUnit(player, 100, Vector2D.create(100, 100));
+        Unit unit = makeUnit(player, Vector2D.create(100, 100));
 
         // find at same position
         EntitiesSet entities = entityRepository.findEntitiesOfTypeAtVector(Vector2D.create(100, 100), EntityType.UNIT);

--- a/src/test/java/com/fundynamic/d2tm/game/entities/PlayerTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/PlayerTest.java
@@ -2,6 +2,7 @@ package com.fundynamic.d2tm.game.entities;
 
 import com.fundynamic.d2tm.game.AbstractD2TMTest;
 import com.fundynamic.d2tm.game.entities.structures.Structure;
+import com.fundynamic.d2tm.game.entities.units.Unit;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -30,14 +31,18 @@ public class PlayerTest extends AbstractD2TMTest {
 
     @Test
     public void hasAliveEntitiesWhenAddingUnitWithEnoughHitPoints() {
-        player.addEntity(makeUnit(player, 100));
+        player.addEntity(makeUnit(player));
 
         assertEquals(1, player.aliveEntities());
     }
 
     @Test
-    public void hasNoAliveEntitiesWhenAddingUnitWithNotEnoughHitPoints() {
-        player.addEntity(makeUnit(player, 0));
+    public void hasNoAliveEntitiesWhenUnitIsDestroyed() {
+        Unit unit = makeUnit(player);
+        unit.takeDamage(unit.getHitPoints()); // destroys unit
+        unit.update(1); // updates internal state so it really is marked destroyed
+
+        player.addEntity(unit);
 
         assertEquals(0, player.aliveEntities());
     }

--- a/src/test/java/com/fundynamic/d2tm/game/entities/projectiles/ProjectileTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/projectiles/ProjectileTest.java
@@ -1,6 +1,5 @@
 package com.fundynamic.d2tm.game.entities.projectiles;
 
-import com.fundynamic.d2tm.Game;
 import com.fundynamic.d2tm.game.AbstractD2TMTest;
 import com.fundynamic.d2tm.game.entities.Entity;
 import com.fundynamic.d2tm.game.entities.EntityData;
@@ -10,7 +9,6 @@ import com.fundynamic.d2tm.math.Vector2D;
 import org.junit.Before;
 import org.junit.Test;
 import org.newdawn.slick.SlickException;
-import org.newdawn.slick.SpriteSheet;
 
 import static com.fundynamic.d2tm.math.Vector2D.create;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -57,7 +55,7 @@ public class ProjectileTest extends AbstractD2TMTest {
     @Before
     public void setUp() throws SlickException {
         super.setUp();
-        projectile = makeProjectileWithOnlyEntityData();
+        projectile = makeProjectile(Vector2D.create(32, 32));
     }
 
     @Test
@@ -159,20 +157,11 @@ public class ProjectileTest extends AbstractD2TMTest {
         assertThat(projectile.getFacing(from, to), is(expectedFacing));
     }
 
-    public Projectile makeProjectileWithOnlyEntityData() {
-        // Given a Projectile with 16 facings, see LargeBullet.png
-        EntityData entityData = new EntityData();
-        entityData.setFacingsAndCalculateChops(16);
-        return new Projectile(null, null, null, entityData, null);
-    }
-
-
     ///////////////////////////////////////
     // projectile movement
 
     @Test
     public void movesToTargetAndExplodes() {
-        Projectile projectile = (Projectile) entityRepository.placeOnMap(Vector2D.create(32, 32), EntityType.PROJECTILE, "LARGE_ROCKET", player);
         EntityData entityData = projectile.getEntityData();
         // movespeed is per second, so we emulate that we want to travel a distance per 2 seconds (ie, 2 update cycles
         // with a delta of 1 second
@@ -198,9 +187,6 @@ public class ProjectileTest extends AbstractD2TMTest {
     // note: yes this also means dealing damage to units owned by same player.
     @Test
     public void movesToTargetAndThenDealsDamageToEntity() {
-        Vector2D coordinate = Vector2D.create(32, 32);
-        Projectile projectile = (Projectile) entityRepository.placeOnMap(coordinate, EntityType.PROJECTILE, "LARGE_ROCKET", player);
-
         EntityData entityData = projectile.getEntityData();
 
         int seconds = 1;
@@ -219,5 +205,15 @@ public class ProjectileTest extends AbstractD2TMTest {
 
         // damage should be dealt, how much damage is not relevant here
         assertThat(unit.getHitPoints(), is(lessThan(unit.getEntityData().hitPoints)));
+    }
+
+    @Test
+    public void projectileCannotTakeDamage() {
+        Projectile projectile = makeProjectile(Vector2D.create(32, 32));
+        int hitPoints = projectile.getHitPoints();
+        projectile.takeDamage(100);
+
+        // damage does nothing
+        assertThat(projectile.getHitPoints(), is(hitPoints));
     }
 }

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
@@ -1,0 +1,61 @@
+package com.fundynamic.d2tm.game.entities.units;
+
+import com.fundynamic.d2tm.math.Vector2D;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class UnitFacingsTest {
+
+    Vector2D unitAbsoluteMapCoordinates = Vector2D.create(32, 32);
+
+    @Test
+    public void determinesFacingRightDown() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 1));
+        assertEquals(UnitFacings.RIGHT_DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingLeftDown() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 1));
+        assertEquals(UnitFacings.LEFT_DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingRightUp() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, -1));
+        assertEquals(UnitFacings.RIGHT_UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingLeftUp() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, -1));
+        assertEquals(UnitFacings.LEFT_UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingUp() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, -1));
+        assertEquals(UnitFacings.UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingDown() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, 1));
+        assertEquals(UnitFacings.DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingLeft() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 0));
+        assertEquals(UnitFacings.LEFT, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+    @Test
+    public void determinesFacingRight() {
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 0));
+        assertEquals(UnitFacings.RIGHT, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+    }
+
+}

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
@@ -4,71 +4,72 @@ import com.fundynamic.d2tm.math.Vector2D;
 import org.junit.Test;
 
 import static com.fundynamic.d2tm.game.entities.units.UnitFacings.*;
+import static com.fundynamic.d2tm.math.Vector2D.create;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 
 public class UnitFacingsTest {
 
-    Vector2D unitAbsoluteMapCoordinates = Vector2D.create(32, 32);
+    Vector2D unitAbsoluteMapCoordinates = create(32, 32);
 
     //////////////////////////////////
     // Determine facing from A to B
 
     @Test
     public void determinesFacingRightDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(1, 1));
         assertEquals(RIGHT_DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeftDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(-1, 1));
         assertEquals(UnitFacings.LEFT_DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingRightUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, -1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(1, -1));
         assertEquals(RIGHT_UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeftUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, -1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(-1, -1));
         assertEquals(LEFT_UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, -1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(0, -1));
         assertEquals(UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, 1));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(0, 1));
         assertEquals(UnitFacings.DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeft() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 0));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(-1, 0));
         assertEquals(LEFT, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingRight() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 0));
+        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(create(1, 0));
         assertEquals(RIGHT, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
 
     ////////////////////////////////////////////////
-    // Facing logic
+    // Facing logic - turning
 
     @Test
-    public void determineNextFacing() {
+    public void determineNextFacingFromCurrentToDesired() {
         assertThat(nextFacing(UP, RIGHT), is(RIGHT_UP));
         assertThat(nextFacing(UP, RIGHT_DOWN), is(RIGHT_UP));
         assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
@@ -79,5 +80,23 @@ public class UnitFacingsTest {
         assertThat(nextFacing(RIGHT_DOWN, RIGHT_UP), is(RIGHT));
 
         assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
+    }
+
+    ////////////////////////////////////////////////
+    // Facing logic - determine desired facing based on 2 vectors
+
+    @Test
+    public void determineDesiredFacingBasedOnVectors() {
+        Vector2D center = create(32, 32);
+        assertThat(getFacing(center, create(64, 64)), is(RIGHT_DOWN));
+        assertThat(getFacing(center, create(64, 32)), is(RIGHT));
+        assertThat(getFacing(center, create(64, 0)), is(RIGHT_UP));
+
+        assertThat(getFacing(center, create(32, 64)), is(DOWN));
+        assertThat(getFacing(center, create(32, 0)), is(UP));
+
+        assertThat(getFacing(center, create(0, 64)), is(LEFT_DOWN));
+        assertThat(getFacing(center, create(0, 32)), is(LEFT));
+        assertThat(getFacing(center, create(0, 0)), is(LEFT_UP));
     }
 }

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.*;
 
 public class UnitFacingsTest {
 
-    Vector2D unitAbsoluteMapCoordinates = create(32, 32);
+    private Vector2D unitAbsoluteMapCoordinates = create(32, 32);
 
     //////////////////////////////////
     // Determine facing from A to B

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
@@ -70,16 +70,16 @@ public class UnitFacingsTest {
 
     @Test
     public void determineNextFacingFromCurrentToDesired() {
-        assertThat(nextFacing(UP, RIGHT), is(RIGHT_UP));
-        assertThat(nextFacing(UP, RIGHT_DOWN), is(RIGHT_UP));
-        assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
-        assertThat(nextFacing(RIGHT_DOWN, LEFT_UP), is(RIGHT));
+        assertThat(nextFacing(UP.getValue(), RIGHT.getValue()), is(RIGHT_UP.getValue()));
+        assertThat(nextFacing(UP.getValue(), RIGHT_DOWN.getValue()), is(RIGHT_UP.getValue()));
+        assertThat(nextFacing(UP.getValue(), LEFT.getValue()), is(LEFT_UP.getValue()));
+        assertThat(nextFacing(RIGHT_DOWN.getValue(), LEFT_UP.getValue()), is(RIGHT.getValue()));
 
         // these force wrapping around on facing indexes, ie RIGHT to RIGHT_DOWN:
-        assertThat(nextFacing(RIGHT, DOWN), is(RIGHT_DOWN));
-        assertThat(nextFacing(RIGHT_DOWN, RIGHT_UP), is(RIGHT));
+        assertThat(nextFacing(RIGHT.getValue(), DOWN.getValue()), is(RIGHT_DOWN.getValue()));
+        assertThat(nextFacing(RIGHT_DOWN.getValue(), RIGHT_UP.getValue()), is(RIGHT.getValue()));
 
-        assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
+        assertThat(nextFacing(UP.getValue(), LEFT.getValue()), is(LEFT_UP.getValue()));
     }
 
     ////////////////////////////////////////////////

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitFacingsTest.java
@@ -3,6 +3,8 @@ package com.fundynamic.d2tm.game.entities.units;
 import com.fundynamic.d2tm.math.Vector2D;
 import org.junit.Test;
 
+import static com.fundynamic.d2tm.game.entities.units.UnitFacings.*;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 
@@ -10,52 +12,72 @@ public class UnitFacingsTest {
 
     Vector2D unitAbsoluteMapCoordinates = Vector2D.create(32, 32);
 
+    //////////////////////////////////
+    // Determine facing from A to B
+
     @Test
     public void determinesFacingRightDown() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 1));
-        assertEquals(UnitFacings.RIGHT_DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(RIGHT_DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeftDown() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 1));
-        assertEquals(UnitFacings.LEFT_DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(UnitFacings.LEFT_DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingRightUp() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, -1));
-        assertEquals(UnitFacings.RIGHT_UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(RIGHT_UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeftUp() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, -1));
-        assertEquals(UnitFacings.LEFT_UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(LEFT_UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingUp() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, -1));
-        assertEquals(UnitFacings.UP, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(UP, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingDown() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, 1));
-        assertEquals(UnitFacings.DOWN, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(UnitFacings.DOWN, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingLeft() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 0));
-        assertEquals(UnitFacings.LEFT, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(LEFT, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
     @Test
     public void determinesFacingRight() {
         Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 0));
-        assertEquals(UnitFacings.RIGHT, UnitFacings.determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
+        assertEquals(RIGHT, determine(unitAbsoluteMapCoordinates, coordinatesToFaceTo));
     }
 
+
+    ////////////////////////////////////////////////
+    // Facing logic
+
+    @Test
+    public void determineNextFacing() {
+        assertThat(nextFacing(UP, RIGHT), is(RIGHT_UP));
+        assertThat(nextFacing(UP, RIGHT_DOWN), is(RIGHT_UP));
+        assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
+        assertThat(nextFacing(RIGHT_DOWN, LEFT_UP), is(RIGHT));
+
+        // these force wrapping around on facing indexes, ie RIGHT to RIGHT_DOWN:
+        assertThat(nextFacing(RIGHT, DOWN), is(RIGHT_DOWN));
+        assertThat(nextFacing(RIGHT_DOWN, RIGHT_UP), is(RIGHT));
+
+        assertThat(nextFacing(UP, LEFT), is(LEFT_UP));
+    }
 }

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
@@ -33,58 +33,11 @@ public class UnitTest extends AbstractD2TMTest {
     }
 
     @Test
-    public void returnsCurrentFacingWhenNothingChanged() {
+    public void returnsRightWhenUnableToFigureOutWhereToFaceTo() {
         assertEquals(UnitFacings.RIGHT, unit.determineFacingFor(unit.getAbsoluteCoordinates()));
     }
 
-    @Test
-    public void determinesFacingRightDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 1));
-        assertEquals(UnitFacings.RIGHT_DOWN, unit.determineFacingFor(coordinatesToFaceTo));
-    }
 
-    @Test
-    public void determinesFacingLeftDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 1));
-        assertEquals(UnitFacings.LEFT_DOWN, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingRightUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, -1));
-        assertEquals(UnitFacings.RIGHT_UP, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingLeftUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, -1));
-        assertEquals(UnitFacings.LEFT_UP, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingUp() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, -1));
-        assertEquals(UnitFacings.UP, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingDown() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(0, 1));
-        assertEquals(UnitFacings.DOWN, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingLeft() {
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(-1, 0));
-        assertEquals(UnitFacings.LEFT, unit.determineFacingFor(coordinatesToFaceTo));
-    }
-
-    @Test
-    public void determinesFacingRight() {
-        unit = makeUnit(UnitFacings.LEFT, unitAbsoluteMapCoordinates);
-        Vector2D coordinatesToFaceTo = unitAbsoluteMapCoordinates.add(Vector2D.create(1, 0));
-        assertEquals(UnitFacings.RIGHT, unit.determineFacingFor(coordinatesToFaceTo));
-    }
 
     @Test
     public void rendersUnitOnExpectedCoordinates() {

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
@@ -95,7 +95,10 @@ public class UnitTest extends AbstractD2TMTest {
 
         assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
 
-        // update 32 'ticks'
+        // for facing
+        unit.update(1);
+
+        // 32 seconds
         for (int tick = 0; tick < 32; tick++) {
             unit.update(1);
         }
@@ -120,7 +123,14 @@ public class UnitTest extends AbstractD2TMTest {
 
         assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
 
-        // update 32 'ticks'
+        // for facing, coming from DOWN to LEFT_UP requires a minimum of 4 steps
+        unit.update(1); // first decide which cell
+        unit.update(1); // then start turning
+        unit.update(1); // until
+        unit.update(1); // we're
+        unit.update(1); // ready to move...
+
+        // and move 32 steps (remember, a unit in a test has a moveSpeed of 1 pixel per 1 second)
         for (int tick = 0; tick < 32; tick++) {
             unit.update(1);
         }

--- a/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/entities/units/UnitTest.java
@@ -2,6 +2,11 @@ package com.fundynamic.d2tm.game.entities.units;
 
 import com.fundynamic.d2tm.game.AbstractD2TMTest;
 import com.fundynamic.d2tm.game.behaviors.FadingSelection;
+import com.fundynamic.d2tm.game.behaviors.HitPointBasedDestructibility;
+import com.fundynamic.d2tm.game.entities.Entity;
+import com.fundynamic.d2tm.game.entities.EntityType;
+import com.fundynamic.d2tm.game.entities.structures.Structure;
+import com.fundynamic.d2tm.game.rendering.RenderQueue;
 import com.fundynamic.d2tm.math.Vector2D;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +16,9 @@ import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 import org.newdawn.slick.SpriteSheet;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -45,7 +53,7 @@ public class UnitTest extends AbstractD2TMTest {
         int offsetY = 6;
         Vector2D offset = Vector2D.create(offsetX, offsetY);
 
-        Unit unit = makeUnit(UnitFacings.DOWN, unitAbsoluteMapCoordinates, offset, 100);
+        Unit unit = makeUnit(UnitFacings.DOWN, unitAbsoluteMapCoordinates, offset);
 
         // TODO: Resolve this quirky thing, because we pass here the coordinates to draw
         // but isn't that basically the unit coordinates * tile size!?
@@ -73,16 +81,20 @@ public class UnitTest extends AbstractD2TMTest {
     }
 
     @Test
-    public void deadUnitUpdateCycle() {
-        FadingSelection fadingSelection = mock(FadingSelection.class);
-        int hitPoints = 100;
-        Unit unit = makeUnit(UnitFacings.DOWN, unitAbsoluteMapCoordinates, Vector2D.zero(), hitPoints);
-        unit.setFadingSelection(fadingSelection);
-
-        unit.takeDamage(hitPoints);
+    public void whenUnitDiesItSpawnsAnExplosion() {
+        Unit unit = makeUnit(player);
+        unit.takeDamage(unit.getHitPoints());
 
         unit.update(1);
 
+        Entity lastCreatedEntity = entityRepository.getLastCreatedEntity();
+        assertThat(lastCreatedEntity.getEntityType(), is(EntityType.PARTICLE));
+        assertThat(lastCreatedEntity.getEntityData().key, is(unit.getEntityData().getExplosionIdKey()));
+
+        // once dead, we don't expect any interactions
+        FadingSelection fadingSelection = mock(FadingSelection.class);
+        unit.setFadingSelection(fadingSelection);
+        unit.update(1);
         verifyZeroInteractions(fadingSelection);
     }
 
@@ -95,20 +107,11 @@ public class UnitTest extends AbstractD2TMTest {
 
         assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
 
-        // for facing
-        unit.update(1);
+        unit.update(0.5F); // decide next cell
+        unit.update(0.5F); // start turning
 
-        // 32 seconds
-        for (int tick = 0; tick < 32; tick++) {
-            unit.update(1);
-        }
-
-        // the unit is about to fully move onto new cell
-        assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
-        assertThat(unit.getOffset(), is(Vector2D.create(31, 31)));
-
-        // one more time
-        unit.update(1);
+        // a QUAD moves 2 squares for 1 second (see rules.ini)
+        unit.update(0.5F);
 
         assertThat(unit.getAbsoluteCoordinates(), is(mapCoordinateToMoveTo));
         assertThat(unit.getOffset(), is(Vector2D.create(0, 0)));
@@ -116,36 +119,48 @@ public class UnitTest extends AbstractD2TMTest {
 
     @Test
     public void verifyUnitMovesToDesiredCellItWantsToMoveToUpperLeftCell() {
-        Unit unit = makeUnit(UnitFacings.DOWN, unitAbsoluteMapCoordinates);
+        Unit unit = makeUnit(UnitFacings.UP, unitAbsoluteMapCoordinates);
 
         Vector2D mapCoordinateToMoveTo = unitAbsoluteMapCoordinates.min(Vector2D.create(32, 32)); // move to left-up
         unit.moveTo(mapCoordinateToMoveTo); // move to left-up
 
         assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
 
-        // for facing, coming from DOWN to LEFT_UP requires a minimum of 4 steps
-        unit.update(1); // first decide which cell
-        unit.update(1); // then start turning
-        unit.update(1); // until
-        unit.update(1); // we're
-        unit.update(1); // ready to move...
+        // for facing, coming from UP to LEFT_UP requires a 1 step
+        unit.update(1); // first decide which movecell, etc
 
-        // and move 32 steps (remember, a unit in a test has a moveSpeed of 1 pixel per 1 second)
-        for (int tick = 0; tick < 32; tick++) {
-            unit.update(1);
-        }
+        // we take 0.5F because turnSpeed is 2 'turns' per second. So half a second is 1 facing per update
+        unit.update(0.5F); // turn towards
 
-        // the unit is about to move, so do not expect it has been moved yet
-        assertThat(unit.getAbsoluteCoordinates(), is(unitAbsoluteMapCoordinates));
-        assertThat(unit.getOffset(), is(Vector2D.create(-31, -31)));
-
-        // one more time
-        unit.update(1);
+        // a QUAD moves 2 squares for 1 second (see rules.ini)
+        unit.update(0.5F);
 
         assertThat(unit.getAbsoluteCoordinates(), is(mapCoordinateToMoveTo));
         assertThat(unit.getOffset(), is(Vector2D.create(0, 0)));
     }
 
+    @Test
+    public void selectedUnitPutsFadingSelectionAndHealthBarOnRenderQueue() {
+        Unit unit = makeUnit(player, Vector2D.create(48, 48));
+        unit.select();
+
+        Vector2D viewportVec = Vector2D.create(32, 32);
+        RenderQueue renderQueue = new RenderQueue(viewportVec);
+        unit.enrichRenderQueue(renderQueue);
+
+        List<RenderQueue.ThingToRender> thingsToRender = renderQueue.getThingsToRender(RenderQueue.ENTITY_GUI_LAYER);
+        assertThat(thingsToRender.size(), is(2));
+
+        RenderQueue.ThingToRender first = thingsToRender.get(0);
+        assertThat(first.renderable, is(instanceOf(HitPointBasedDestructibility.class)));
+        assertThat(first.x, is(16)); // unitX - viewportVecX
+        assertThat(first.y, is(16)); // unitY - viewportVecY
+
+        RenderQueue.ThingToRender second = thingsToRender.get(1);
+        assertThat(second.renderable, is(instanceOf(FadingSelection.class)));
+        assertThat(second.x, is(16)); // unitX - viewportVecX
+        assertThat(second.y, is(16)); // unitY - viewportVecY
+    }
 
     public static SpriteSheet makeSpriteSheet() {
         SpriteSheet spriteSheet = mock(SpriteSheet.class);

--- a/src/test/java/com/fundynamic/d2tm/game/rendering/ViewportTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/rendering/ViewportTest.java
@@ -21,7 +21,7 @@ public class ViewportTest extends AbstractD2TMTest {
         Graphics bufferGraphics = mock(Graphics.class);
         when(bufferWithGraphics.getGraphics()).thenReturn(bufferGraphics);
 
-        makeUnit(player, 100, Vector2D.create(2, 2));
+        makeUnit(player, Vector2D.create(2, 2));
         map.revealAllShroudFor(player);
 
         Viewport viewport = new Viewport(map, mouse, player, bufferWithGraphics);

--- a/src/test/java/com/fundynamic/d2tm/game/state/PlayingStateTest.java
+++ b/src/test/java/com/fundynamic/d2tm/game/state/PlayingStateTest.java
@@ -78,14 +78,15 @@ public class PlayingStateTest extends AbstractD2TMTest {
     @Test
     public void updateRemovesDestroyedEntities() throws SlickException {
         StateBasedGame game = mock(StateBasedGame.class);
-        Unit unit = makeUnit(player, 100);
+        Unit unit = makeUnit(player);
         int originalCount = entityRepository.getEntitiesCount();
 
         // keep unit alive
         playingState.update(gameContainer, game, 10);
         assertThat(entityRepository.getEntitiesCount(), is(originalCount));
 
-        unit.takeDamage(100); // takes damage, so it gets destroyed
+        unit.takeDamage(unit.getHitPoints()); // takes damage, so it gets destroyed
+        unit.update(1);       // required to update internal state
         assertThat(unit.isDestroyed(), is(true));
 
         playingState.update(gameContainer, game, 10);

--- a/src/test/resources/test-rules.ini
+++ b/src/test/resources/test-rules.ini
@@ -38,6 +38,7 @@ width=32
 height=32
 sight=7
 movespeed=1.5
+turnspeed=0.75
 hitpoints=434
 explosion=BOOM
 weapon=RIFLE


### PR DESCRIPTION
This fixed #63 

- introduces `turnspeed` property of unit
- fixes that all `move` and `turn` speed things are now time based, and not fps based.

/cc @arjenvanderende 