### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.1.0</version>
+				<version>4.2.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>


### PR DESCRIPTION
for:
https://github.com/Fundynamic/dune2themaker4j/issues/112

todo:
- [ ] figure out why mvn-jar-plugin update to `3.0.0` seems to break the `manifest.mf` file:

mvn-plugin 2.6 generates:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Built-By: stefa
Class-Path: lib/org/slick2d/slick2d-core/1.0.1/slick2d-core-1.0.1.jar 
 lib/org/lwjgl/lwjgl/lwjgl/2.9.1/lwjgl-2.9.1.jar lib/org/lwjgl/lwjgl/l
 wjgl-platform/2.9.1/lwjgl-platform-2.9.1-natives-windows.jar lib/org/
 lwjgl/lwjgl/lwjgl-platform/2.9.1/lwjgl-platform-2.9.1-natives-linux.j
 ar lib/org/lwjgl/lwjgl/lwjgl-platform/2.9.1/lwjgl-platform-2.9.1-nati
 ves-osx.jar lib/net/java/jinput/jinput/2.0.5/jinput-2.0.5.jar lib/net
 /java/jutils/jutils/1.0.0/jutils-1.0.0.jar lib/net/java/jinput/jinput
 -platform/2.0.5/jinput-platform-2.0.5-natives-linux.jar lib/net/java/
 jinput/jinput-platform/2.0.5/jinput-platform-2.0.5-natives-windows.ja
 r lib/net/java/jinput/jinput-platform/2.0.5/jinput-platform-2.0.5-nat
 ives-osx.jar lib/org/jcraft/jorbis/0.0.17/jorbis-0.0.17.jar lib/org/i
 ni4j/ini4j/0.5.4/ini4j-0.5.4.jar
Created-By: Apache Maven 3.3.9
Build-Jdk: 1.8.0_91
Main-Class: com.fundynamic.d2tm.Game
```

and `3.0.0` generates:
```
Manifest-Version: 1.0
Archiver-Version: Plexus Archiver
Built-By: stefa
Class-Path: lib/slick2d-core-1.0.1.jar lib/lwjgl-2.9.1.jar lib/lwjgl-p
 latform-2.9.1-natives-windows.jar lib/lwjgl-platform-2.9.1-natives-li
 nux.jar lib/lwjgl-platform-2.9.1-natives-osx.jar lib/jinput-2.0.5.jar
  lib/jutils-1.0.0.jar lib/jinput-platform-2.0.5-natives-linux.jar lib
 /jinput-platform-2.0.5-natives-windows.jar lib/jinput-platform-2.0.5-
 natives-osx.jar lib/jorbis-0.0.17.jar lib/ini4j-0.5.4.jar
Created-By: Apache Maven 3.3.9
Build-Jdk: 1.8.0_91
Main-Class: com.fundynamic.d2tm.Game
```

generated on a windows machine.