### PR TITLE
All units but harvesters animate when moving

### DIFF
--- a/src/main/java/com/fundynamic/d2tm/game/entities/units/states/GoalResolverState.java
+++ b/src/main/java/com/fundynamic/d2tm/game/entities/units/states/GoalResolverState.java
@@ -20,12 +20,16 @@ public class GoalResolverState extends UnitState {
 
         if (!unit.shouldMove()) {
             unit.idle();
+            unit.stopAndResetAnimating();
             return;
         }
 
         if (unit.hasNoNextCellToMoveTo()) {
             Coordinate nextIntendedCoordinatesToMoveTo = unit.getNextIntendedCellToMoveToTarget();
             if (unit.isCellPassableForMe(nextIntendedCoordinatesToMoveTo)) {
+                if (!unit.isHarvester()) {
+                    unit.startAnimating();
+                }
                 unit.moveToCell(nextIntendedCoordinatesToMoveTo);
             }
         } else {


### PR DESCRIPTION
Fixes #166 in a hacky way, but we can make this more abstract later.